### PR TITLE
Dataset URI pattern changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 L-RdfToVirtuosoAndCkan
 ----------
 
-v1.1.6-SNAPSHOT
+v1.2.0-SNAPSHOT
 ---
-N/A
+* dataset uri pattern parameters names changed to be clearer and more unique to prevent conflicts with Maven build properties
+* new pattern: https://host/internalcatalog/dataset/${ckan_package_id} OR https://host/internalcatalog/dataset/${ckan_package_name}
 
 v1.1.5-SNAPSHOT
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ v1.2.0-SNAPSHOT
 * dataset uri pattern parameters names changed to be clearer and more unique to prevent conflicts with Maven build properties
 * new pattern: https://host/internalcatalog/dataset/${ckan_package_id} OR https://host/internalcatalog/dataset/${ckan_package_name}
 
-v1.1.5-SNAPSHOT
+v1.1.5
 ---
 * Update to API 2.1.4
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,13 @@ These properties have to be set in backend.properties of UnifiedViews for correc
 |`org.opendatanode.CKAN.http.header.[key]`| Custom HTTP header added to requests on CKAN |
 
 
+#### Dataset URI pattern
+URI pattern can contain 2 placeholders, which are replaced during execution of the DPU. URI pattern can contain none, one or both placeholders.
+* ckan_package_id - replaced by ID of CKAN package (dataset) mapped to the executing pipeline
+* ckan_name_id    - replaced by name of CKAN package (dataset) mapped to the executing pipeline
+
+For more details, see Examples
+
 #### Examples
 
 ```INI
@@ -29,13 +36,13 @@ org.opendatanode.CKAN.http.header.X-Forwarded-Proto = https
 ```
 
 ```INI
-dpu.uv-l-rdfToVirtuosoAndCkan.dataset.uri.pattern = https://host/internalcatalog/dataset/${id}
+dpu.uv-l-rdfToVirtuosoAndCkan.dataset.uri.pattern = https://host/internalcatalog/dataset/${ckan_package_id}
 ```
 example Virtuoso graph name https://host/internalcatalog/dataset/452fddaa-c469-4b78-823d-320fb1bd8646.
 Notice the 452fddaa-c469-4b78-823d-320fb1bd8646 - id of CKAN dataset.
 
 ```INI
-dpu.uv-l-rdfToVirtuosoAndCkan.dataset.uri.pattern = https://host/internalcatalog/dataset/${name}
+dpu.uv-l-rdfToVirtuosoAndCkan.dataset.uri.pattern = https://host/internalcatalog/dataset/${ckan_package_name}
 ```
 example Virtuoso graph name https://host/internalcatalog/dataset/my-dataset-name
 Notice the my-dataset-name - name property of CKAN dataset (the one from URL of dataset).

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>uv-l-rdfToVirtuosoAndCkan</artifactId>
     <name>L-RdfToVirtuosoAndCkan</name>
     <description>Loads RDF data to Virtuoso using L-RdfToVirtuoso and creates CKAN resources using L-RdfToCkan.</description>
-    <version>1.1.6-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
     <packaging>bundle</packaging>
 
     <properties>

--- a/src/main/java/org/opendatanode/plugins/loader/rdftovirtuosoandckan/RdfToVirtuosoAndCkan.java
+++ b/src/main/java/org/opendatanode/plugins/loader/rdftovirtuosoandckan/RdfToVirtuosoAndCkan.java
@@ -43,6 +43,10 @@ public class RdfToVirtuosoAndCkan extends AbstractDpu<RdfToVirtuosoAndCkanConfig
 
     public static final String CONFIGURATION_RESOURCE_NAME = "dpu.uv-l-rdfToVirtuosoAndCkan.resource.name";
 
+    public static final String DATASET_URI_ID_PLACEHOLDER = "ckan_package_id";
+
+    public static final String DATASET_URI_NAME_PLACEHOLDER = "ckan_package_name";
+
     public RdfToVirtuosoAndCkan() {
         super(RdfToVirtuosoAndCkanVaadinDialog.class, ConfigHistory.noHistory(RdfToVirtuosoAndCkanConfig_V1.class));
     }
@@ -82,8 +86,8 @@ public class RdfToVirtuosoAndCkan extends AbstractDpu<RdfToVirtuosoAndCkanConfig
 
         JsonObject dataset = rdfToCkan.packageShow(ctx, catalogApiLocation, pipelineId, userId, secretToken, additionalHttpHeaders);
         Map<String, String> args = new HashMap<>();
-        args.put("id", dataset.getJsonObject("result").getString("id"));
-        args.put("name", dataset.getJsonObject("result").getString("name"));
+        args.put(DATASET_URI_ID_PLACEHOLDER, dataset.getJsonObject("result").getString("id"));
+        args.put(DATASET_URI_NAME_PLACEHOLDER, dataset.getJsonObject("result").getString("name"));
         StrSubstitutor sub = new StrSubstitutor(args);
         String datasetUri = sub.replace(datasetUriPattern);
 


### PR DESCRIPTION
Dataset URI pattern parameter names changed to be clearer and more unique as the old values conflicted with Maven build properties. 
When Maven used to filter resources with properties, URI parameters were replaced by some internal Maven properties.
By introducing the new parameter names, there is much less chance there will be conflict with other properties
